### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/sql/aggregate.py
+++ b/sql/aggregate.py
@@ -91,17 +91,16 @@ class Aggregate(Expression):
 
     def __str__(self):
         quantifier = 'DISTINCT ' if self.distinct else ''
-        aggregate = '%s(%s%s)' % (self._sql, quantifier, self.expression)
+        aggregate = '{0!s}({1!s}{2!s})'.format(self._sql, quantifier, self.expression)
         within = ''
         if self.within:
-            within = (' WITHIN GROUP (ORDER BY %s)'
-                      % ', '.join(map(str, self.within)))
+            within = (' WITHIN GROUP (ORDER BY {0!s})'.format(', '.join(map(str, self.within))))
         filter_ = ''
         if self.filter_:
-            filter_ = ' FILTER (WHERE %s)' % self.filter_
+            filter_ = ' FILTER (WHERE {0!s})'.format(self.filter_)
         window = ''
         if self.window:
-            window = ' OVER "%s"' % self.window.alias
+            window = ' OVER "{0!s}"'.format(self.window.alias)
         return aggregate + within + filter_ + window
 
     @property

--- a/sql/conditionals.py
+++ b/sql/conditionals.py
@@ -55,10 +55,10 @@ class Case(Conditional):
     def __str__(self):
         case = 'CASE '
         for cond, result in self.whens:
-            case += 'WHEN %s THEN %s ' % (
+            case += 'WHEN {0!s} THEN {1!s} '.format(
                 self._format(cond), self._format(result))
         if self.else_ is not None:
-            case += 'ELSE %s ' % self._format(self.else_)
+            case += 'ELSE {0!s} '.format(self._format(self.else_))
         case += 'END'
         return case
 

--- a/sql/functions.py
+++ b/sql/functions.py
@@ -62,7 +62,7 @@ class Function(Expression, FromItem):
 
     @property
     def columns_definitions(self):
-        return ', '.join('"%s" %s' % (c, d)
+        return ', '.join('"{0!s}" {1!s}'.format(c, d)
                          for c, d in self._columns_definitions)
 
     @columns_definitions.setter
@@ -330,7 +330,7 @@ class Trim(Function):
             else:
                 return str(arg)
 
-        return self._function + '(%s %s FROM %s)' % (
+        return self._function + '({0!s} {1!s} FROM {2!s})'.format(
             self.position, format(self.characters), format(self.string))
 
     @property
@@ -476,7 +476,7 @@ class AtTimeZone(Function):
         if Mapping:
             return str(Mapping(self.field, self.zone))
         param = flavor.param
-        return '%s AT TIME ZONE %s' % (str(self.field), param)
+        return '{0!s} AT TIME ZONE {1!s}'.format(str(self.field), param)
 
     @property
     def params(self):
@@ -519,8 +519,8 @@ class WindowFunction(Function):
         function = super(WindowFunction, self).__str__()
         filter_ = ''
         if self.filter_:
-            filter_ = ' FILTER (WHERE %s)' % self.filter_
-        over = ' OVER "%s"' % self.window.alias
+            filter_ = ' FILTER (WHERE {0!s})'.format(self.filter_)
+        over = ' OVER "{0!s}"'.format(self.window.alias)
         return function + filter_ + over
 
     @property

--- a/sql/operators.py
+++ b/sql/operators.py
@@ -79,7 +79,7 @@ class Operator(Expression):
         if isinstance(operand, Expression):
             return str(operand)
         elif isinstance(operand, (Select, CombiningQuery)):
-            return '(%s)' % operand
+            return '({0!s})'.format(operand)
         elif isinstance(operand, (list, tuple)):
             return '(' + ', '.join(self._format(o, param)
                                    for o in operand) + ')'
@@ -116,7 +116,7 @@ class UnaryOperator(Operator):
         return self.operand,
 
     def __str__(self):
-        return '(%s %s)' % (self._operator, self._format(self.operand))
+        return '({0!s} {1!s})'.format(self._operator, self._format(self.operand))
 
 
 class BinaryOperator(Operator):
@@ -133,7 +133,7 @@ class BinaryOperator(Operator):
 
     def __str__(self):
         left, right = self._operands
-        return '(%s %s %s)' % (self._format(left), self._operator,
+        return '({0!s} {1!s} {2!s})'.format(self._format(left), self._operator,
                                self._format(right))
 
     def __invert__(self):
@@ -149,7 +149,7 @@ class NaryOperator(list, Operator):
         return self
 
     def __str__(self):
-        return '(' + (' %s ' % self._operator).join(map(str, self)) + ')'
+        return '(' + (' {0!s} '.format(self._operator)).join(map(str, self)) + ')'
 
 
 class And(NaryOperator):
@@ -211,9 +211,9 @@ class Equal(BinaryOperator):
 
     def __str__(self):
         if self.left is Null:
-            return '(%s IS NULL)' % self.right
+            return '({0!s} IS NULL)'.format(self.right)
         elif self.right is Null:
-            return '(%s IS NULL)' % self.left
+            return '({0!s} IS NULL)'.format(self.left)
         return super(Equal, self).__str__()
 
 
@@ -223,9 +223,9 @@ class NotEqual(Equal):
 
     def __str__(self):
         if self.left is Null:
-            return '(%s IS NOT NULL)' % self.right
+            return '({0!s} IS NOT NULL)'.format(self.right)
         elif self.right is Null:
-            return '(%s IS NOT NULL)' % self.left
+            return '({0!s} IS NOT NULL)'.format(self.left)
         return super(Equal, self).__str__()
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:python-sql?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:python-sql?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
